### PR TITLE
fix: prevent WAN Up Since from updating every poll cycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This is a Home Assistant custom integration (`peplink_local`) for monitoring Peplink routers via their local API. It is distributed via HACS and requires Home Assistant 2025.1.0+.
+
+## Dependencies
+
+All `homeassistant.*` imports can be assumed to exist at runtime — do not attempt to install or verify them locally. The integration runs inside Home Assistant which provides these packages.
+
+## Development Commands
+
+**Run the standalone API test against a real router:**
+```bash
+# Copy and configure .env first
+cp .env.example .env  # or let standalone_test.py generate it
+# Then run:
+bash tests/run_api_test.sh
+# Or directly:
+python3 tests/standalone_test.py
+```
+
+The test script requires a `.env` file in the project root with:
+```
+PEPLINK_ROUTER_IP=192.168.1.1
+PEPLINK_USERNAME=admin
+PEPLINK_PASSWORD=your_password
+PEPLINK_VERIFY_SSL=false
+```
+
+Test output (raw JSON responses from each API endpoint) is saved to `tests/output/`.
+
+## Architecture
+
+### Data Flow
+
+`PeplinkAPI` (peplink_api.py) → `PeplinkDataUpdateCoordinator` (__init__.py) → platform entities (sensor.py, binary_sensor.py, device_tracker.py)
+
+The coordinator calls five API methods in parallel via `asyncio.gather`:
+1. `get_wan_status()` → WAN connection info
+2. `get_clients()` → connected client devices
+3. `get_system_info()` → combined call returning device info, thermal sensors, fan speeds, system time
+4. `get_traffic_stats()` → per-WAN bandwidth rates
+5. `get_location()` → GPS data (returns `gps: false` if router has no GPS)
+
+All coordinator data is stored under `hass.data[DOMAIN][entry_id]["coordinator"].data` as a flat dict with keys: `wan_status`, `clients`, `thermal_sensors`, `fan_speeds`, `traffic_stats`, `device_info`, `system_time`, `location_info`.
+
+### API Layer (peplink_api.py)
+
+Two API bases are used:
+- **Official API**: `https://{host}/api/` — authentication (`/api/login`), WAN status (`/api/status.wan.connection`), clients (`/api/status.client`)
+- **Unofficial CGI API**: `https://{host}/cgi-bin/MANGA/api.cgi?func=<function>&_=<timestamp>` — traffic stats, fan speeds, thermal sensors, device info, GPS location
+
+Authentication uses cookie-based sessions (`bauth` cookie). The `_` parameter in CGI requests is the current Unix timestamp in milliseconds.
+
+### Entity Model
+
+Each WAN connection creates a sub-device (via `via_device`) linked to the main router device. WAN entities use `identifiers={(DOMAIN, f"{entry_id}_wan{wan_id}")}`.
+
+- **sensor.py**: Defines `SENSOR_TYPES` tuple of `PeplinkSensorEntityDescription` (with `value_fn` lambdas). Static sensors (temperature, device info, GPS, fans) use `PeplinkSensor`. Per-WAN sensors use `PeplinkWANSensor`, which routes traffic data from `traffic_stats` and connection data from `wan_status`.
+- **binary_sensor.py**: One `connection_status` binary sensor per enabled WAN, checking if `message.startswith("Connected")`.
+- **device_tracker.py**: `PeplinkClientTracker` (one per client MAC) + optional `PeplinkGPSTracker` if GPS is available.
+
+### Key Data Structure Notes
+
+- `wan_status["connection"]` is a list of dicts, each with `"id"` field (integer)
+- `traffic_stats["stats"]` is a list with `"wan_id"` field — matched to WAN connections by string comparison
+- `system_info` from `get_system_info()` combines four separate CGI calls into one dict
+- GPS sensors/tracker are only created if `location_info["gps"] == True` and valid lat/lon exist
+- Fan sensors are created dynamically (numbered fan_1, fan_2, etc.) based on what the router reports

--- a/custom_components/peplink_local/sensor.py
+++ b/custom_components/peplink_local/sensor.py
@@ -35,6 +35,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 from homeassistant.util import dt as dt_util
+from homeassistant.util.variance import ignore_variance
 from homeassistant.config_entries import ConfigEntry
 
 from . import PeplinkDataUpdateCoordinator
@@ -58,6 +59,11 @@ class PeplinkBinarySensorEntityDescription(BinarySensorEntityDescription):
     value_fn: Callable[[dict], Any] | None = None
     icon: str | None = None
 
+
+uptime_to_stable_datetime = ignore_variance(
+    lambda value: dt_util.utcnow() - datetime.timedelta(seconds=value),
+    datetime.timedelta(minutes=1),
+)
 
 SENSOR_TYPES: tuple[PeplinkSensorEntityDescription, ...] = (
     # System sensors
@@ -199,7 +205,7 @@ SENSOR_TYPES: tuple[PeplinkSensorEntityDescription, ...] = (
         state_class=None,
         # Calculate the "up since" timestamp by subtracting uptime from current time
         value_fn=lambda x: (
-            dt_util.utcnow() - datetime.timedelta(seconds=x.get("uptime"))
+            uptime_to_stable_datetime(x.get("uptime"))
             if x.get("uptime") is not None
             else None
         ),


### PR DESCRIPTION
Fixes #12

## Problem

The `WAN Up Since` timestamp is computed as `utcnow() - timedelta(seconds=uptime)` on every coordinator poll (default every 5s). Because `utcnow()` advances with each call, the resulting timestamp is always slightly different, causing Home Assistant to record a state change every poll — leading to log spam and excessive database writes.

## Fix

Apply `homeassistant.util.variance.ignore_variance` with a 1-minute tolerance to the uptime-to-datetime conversion. The sensor value now only updates when the computed timestamp drifts more than 1 minute from the previously reported value.

This mirrors the fix applied to the Starlink integration in home-assistant/core#155574.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)